### PR TITLE
Fix project URLs and bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tessera-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for Tessera - Data contract coordination for warehouses"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Fixes PyPI project URLs to point to tessera-python repo instead of tessera server repo.