### PR TITLE
Release v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tessera-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python SDK for Tessera - Data contract coordination for warehouses"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Bump version to 0.1.3 to match tessera-contracts server

## Test plan
- [x] All tests pass (15/15)
- [x] Version updated in pyproject.toml

After merge, create v0.1.3 release to trigger PyPI publish.