### PR TITLE
Add tiered acknowledgment model support for Tessera v0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tessera-sdk"
-version = "0.1.3"
+version = "0.1.4"
 description = "Python SDK for Tessera - Data contract coordination for warehouses"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/tessera_sdk/__init__.py
+++ b/src/tessera_sdk/__init__.py
@@ -70,6 +70,8 @@ from tessera_sdk.models import (
     Guarantees,
     ImpactAnalysis,
     LineageResponse,
+    ObjectionCreate,
+    ObjectionResponse,
     Proposal,
     ProposalCreate,
     ProposalStatus,
@@ -84,7 +86,7 @@ from tessera_sdk.models import (
     TeamUpdate,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.1.4"
 
 __all__ = [
     # Clients
@@ -128,5 +130,7 @@ __all__ = [
     "DependencyCreate",
     "ImpactAnalysis",
     "LineageResponse",
+    "ObjectionCreate",
+    "ObjectionResponse",
     "PublishResult",
 ]

--- a/src/tessera_sdk/models.py
+++ b/src/tessera_sdk/models.py
@@ -224,12 +224,34 @@ class Proposal(BaseModel):
     proposed_by: UUID
     proposed_at: datetime
     resolved_at: datetime | None = None
+    # Tiered acknowledgment fields (v0.1.5+)
+    affected_teams: list[dict[str, Any]] = Field(default_factory=list)
+    affected_assets: list[dict[str, Any]] = Field(default_factory=list)
+    objections: list[dict[str, Any]] = Field(default_factory=list)
+    has_objections: bool = False
 
 
 class ProposalCreate(BaseModel):
     """Fields for creating a proposal."""
 
     proposed_schema: dict[str, Any]
+
+
+class ObjectionCreate(BaseModel):
+    """Fields for filing an objection to a proposal."""
+
+    reason: str = Field(..., min_length=1, max_length=1000)
+
+
+class ObjectionResponse(BaseModel):
+    """Response from filing an objection."""
+
+    action: str
+    proposal_id: str
+    asset_fqn: str
+    objection: dict[str, Any]
+    total_objections: int
+    note: str
 
 
 # Acknowledgment models

--- a/src/tessera_sdk/resources.py
+++ b/src/tessera_sdk/resources.py
@@ -21,6 +21,8 @@ from tessera_sdk.models import (
     DependencyType,
     ImpactAnalysis,
     LineageResponse,
+    ObjectionCreate,
+    ObjectionResponse,
     Proposal,
     ProposalStatus,
     ProposalStatusResponse,
@@ -794,6 +796,35 @@ class ProposalsResource:
         response = self._http.post(f"{self._base}/{proposal_id}/publish")
         return Contract.model_validate(response)
 
+    def file_objection(
+        self,
+        proposal_id: UUID | str,
+        objector_team_id: UUID | str,
+        reason: str,
+        objector_user_id: UUID | str | None = None,
+    ) -> ObjectionResponse:
+        """File an objection to a proposal.
+
+        Args:
+            proposal_id: The proposal to object to.
+            objector_team_id: The team filing the objection.
+            reason: The reason for the objection (1-1000 chars).
+            objector_user_id: Optional user ID filing the objection.
+
+        Returns:
+            ObjectionResponse with objection details.
+        """
+        data = ObjectionCreate(reason=reason)
+        params: dict[str, Any] = {"objector_team_id": str(objector_team_id)}
+        if objector_user_id:
+            params["objector_user_id"] = str(objector_user_id)
+        response = self._http.post(
+            f"{self._base}/{proposal_id}/object",
+            json=data.model_dump(),
+            params=params,
+        )
+        return ObjectionResponse.model_validate(response)
+
 
 class AsyncProposalsResource:
     """Proposals API resource (async)."""
@@ -860,3 +891,32 @@ class AsyncProposalsResource:
         """Publish an approved proposal as a new contract."""
         response = await self._http.post(f"{self._base}/{proposal_id}/publish")
         return Contract.model_validate(response)
+
+    async def file_objection(
+        self,
+        proposal_id: UUID | str,
+        objector_team_id: UUID | str,
+        reason: str,
+        objector_user_id: UUID | str | None = None,
+    ) -> ObjectionResponse:
+        """File an objection to a proposal.
+
+        Args:
+            proposal_id: The proposal to object to.
+            objector_team_id: The team filing the objection.
+            reason: The reason for the objection (1-1000 chars).
+            objector_user_id: Optional user ID filing the objection.
+
+        Returns:
+            ObjectionResponse with objection details.
+        """
+        data = ObjectionCreate(reason=reason)
+        params: dict[str, Any] = {"objector_team_id": str(objector_team_id)}
+        if objector_user_id:
+            params["objector_user_id"] = str(objector_user_id)
+        response = await self._http.post(
+            f"{self._base}/{proposal_id}/object",
+            json=data.model_dump(),
+            params=params,
+        )
+        return ObjectionResponse.model_validate(response)

--- a/uv.lock
+++ b/uv.lock
@@ -623,7 +623,7 @@ wheels = [
 
 [[package]]
 name = "tessera-sdk"
-version = "0.1.1"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Add `affected_teams`, `affected_assets`, `objections`, `has_objections` fields to Proposal model
- Add `ObjectionCreate` and `ObjectionResponse` models for filing objections
- Add `file_objection` method to `ProposalsResource` and `AsyncProposalsResource`
- Bump version to 0.1.4

## Test plan

- [x] All existing tests pass (15/15)
- [x] Linting passes (ruff check)
- [x] Type checking passes (mypy)