### PR TITLE
Add team delete/restore and asset reassign APIs

### DIFF
--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -38,12 +38,32 @@ team = client.teams.create(
 )
 ```
 
-#### delete(team_id: str) -> None
+#### delete(team_id: str, force: bool = False) -> None
 
-Delete a team.
+Soft delete a team. Use `force=True` if the team still owns assets.
 
 ```python
-client.teams.delete("team-uuid")
+client.teams.delete("team-uuid", force=True)
+```
+
+#### restore(team_id: str) -> Team
+
+Restore a soft-deleted team.
+
+```python
+restored = client.teams.restore("team-uuid")
+```
+
+#### reassign_assets(team_id: str, target_team_id: str, asset_ids: list[str] | None = None) -> dict
+
+Reassign assets to another team before deletion.
+
+```python
+client.teams.reassign_assets(
+    team_id="team-uuid",
+    target_team_id="target-team-uuid",
+    asset_ids=["asset-id-1", "asset-id-2"],
+)
 ```
 
 ---

--- a/src/tessera_sdk/resources.py
+++ b/src/tessera_sdk/resources.py
@@ -85,6 +85,29 @@ class TeamsResource:
         )
         return Team.model_validate(response)
 
+    def delete(self, team_id: UUID | str, force: bool = False) -> None:
+        """Soft delete a team. Use force=True if the team has assets."""
+        params = {"force": "true"} if force else None
+        self._http.delete(f"{self._base}/{team_id}", params=params)
+
+    def restore(self, team_id: UUID | str) -> Team:
+        """Restore a soft-deleted team."""
+        response = self._http.post(f"{self._base}/{team_id}/restore")
+        return Team.model_validate(response)
+
+    def reassign_assets(
+        self,
+        team_id: UUID | str,
+        target_team_id: UUID | str,
+        asset_ids: list[UUID] | None = None,
+    ) -> dict[str, Any]:
+        """Reassign assets to another team before deletion."""
+        payload: dict[str, Any] = {"target_team_id": str(target_team_id)}
+        if asset_ids is not None:
+            payload["asset_ids"] = [str(a) for a in asset_ids]
+
+        return self._http.post(f"{self._base}/{team_id}/reassign-assets", json=payload)
+
 
 class AsyncTeamsResource:
     """Teams API resource (async)."""
@@ -130,6 +153,29 @@ class AsyncTeamsResource:
             json=data.model_dump(exclude_none=True),
         )
         return Team.model_validate(response)
+
+    async def delete(self, team_id: UUID | str, force: bool = False) -> None:
+        """Soft delete a team. Use force=True if the team has assets."""
+        params = {"force": "true"} if force else None
+        await self._http.delete(f"{self._base}/{team_id}", params=params)
+
+    async def restore(self, team_id: UUID | str) -> Team:
+        """Restore a soft-deleted team."""
+        response = await self._http.post(f"{self._base}/{team_id}/restore")
+        return Team.model_validate(response)
+
+    async def reassign_assets(
+        self,
+        team_id: UUID | str,
+        target_team_id: UUID | str,
+        asset_ids: list[UUID] | None = None,
+    ) -> dict[str, Any]:
+        """Reassign assets to another team before deletion."""
+        payload: dict[str, Any] = {"target_team_id": str(target_team_id)}
+        if asset_ids is not None:
+            payload["asset_ids"] = [str(a) for a in asset_ids]
+
+        return await self._http.post(f"{self._base}/{team_id}/reassign-assets", json=payload)
 
 
 class AssetsResource:

--- a/tests/test_teams_resource.py
+++ b/tests/test_teams_resource.py
@@ -1,0 +1,63 @@
+import uuid
+
+from pytest_httpx import HTTPXMock
+
+from tessera_sdk import TesseraClient
+
+
+def test_delete_team(httpx_mock: HTTPXMock) -> None:
+    team_id = uuid.uuid4()
+    httpx_mock.add_response(
+        url=f"http://test.local/api/v1/teams/{team_id}",
+        method="DELETE",
+        status_code=204,
+    )
+
+    with TesseraClient(base_url="http://test.local") as client:
+        client.teams.delete(team_id)
+
+
+def test_force_delete_team(httpx_mock: HTTPXMock) -> None:
+    team_id = uuid.uuid4()
+    httpx_mock.add_response(
+        url=f"http://test.local/api/v1/teams/{team_id}?force=true",
+        method="DELETE",
+        status_code=204,
+    )
+
+    with TesseraClient(base_url="http://test.local") as client:
+        client.teams.delete(team_id, force=True)
+
+
+def test_restore_team(httpx_mock: HTTPXMock) -> None:
+    team_id = uuid.uuid4()
+    httpx_mock.add_response(
+        url=f"http://test.local/api/v1/teams/{team_id}/restore",
+        method="POST",
+        json={
+            "id": str(team_id),
+            "name": "data-platform",
+            "metadata": {},
+            "created_at": "2024-01-01T00:00:00Z",
+        },
+    )
+
+    with TesseraClient(base_url="http://test.local") as client:
+        team = client.teams.restore(team_id)
+        assert team.id == team_id
+        assert team.name == "data-platform"
+
+
+def test_reassign_assets(httpx_mock: HTTPXMock) -> None:
+    team_id = uuid.uuid4()
+    target_team = uuid.uuid4()
+    assets = [uuid.uuid4(), uuid.uuid4()]
+    httpx_mock.add_response(
+        url=f"http://test.local/api/v1/teams/{team_id}/reassign-assets",
+        method="POST",
+        json={"status": "ok"},
+    )
+
+    with TesseraClient(base_url="http://test.local") as client:
+        result = client.teams.reassign_assets(team_id, target_team, assets)
+        assert result == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add TeamsResource methods for delete (with force), restore, and reassign-assets to match core API endpoints
- mirror the same methods in AsyncTeamsResource
- document the new methods and add coverage for the new endpoints

## Rationale
The SDK was missing the team lifecycle endpoints (delete/restore/reassign-assets) present in the core API; this exposes them for clients.

## Changes
- implement sync/async delete (optional force), restore, and reassign_assets calls under /api/v1/teams
- update docs/api/resources.md for the new team methods
- add tests for the new team endpoints

Fixes #15